### PR TITLE
Minor fixes

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -229,16 +229,16 @@ endif()
 
 
 # --------------------------------------------------------------------------- #
+# PYBIND11
+# --------------------------------------------------------------------------- #
+add_subdirectory(pybind11)
+
+
+# --------------------------------------------------------------------------- #
 # PYTHON
 # --------------------------------------------------------------------------- #
 find_package(PythonLibs REQUIRED)
 include_directories(${PYTHON_INCLUDE_PATH})
-
-
-# --------------------------------------------------------------------------- #
-# PYBIND11
-# --------------------------------------------------------------------------- #
-add_subdirectory(pybind11)
 
 
 # --------------------------------------------------------------------------- #
@@ -259,14 +259,6 @@ set(MAKE_LIB BOOL ON)
 foreach(SRC ${SRCS})
     get_filename_component(MOD ${SRC} NAME_WE)
 
-    # Check for system-specific modules
-    # message(STATUS "Mod: ${MOD}")
-    if((WIN32 AND (${MOD} STREQUAL "XwWindow"))
-        OR ((NOT WIN32) AND (${MOD} STREQUAL "WNT")))
-            message(STATUS "Skipping system-specific module ${MOD}")
-            continue()
-    endif()
-
     # Check for SMESH modules
     list(FIND SMESH_MODULES ${MOD} _INDEX)
     if(NOT ENABLE_SMESH AND ${_INDEX} GREATER -1)
@@ -284,6 +276,13 @@ foreach(SRC ${SRCS})
     if(NOT ENABLE_BLSURF AND ${MOD} STREQUAL "BLSURFPlugin" AND MAKE_LIB)
         message(STATUS "Skipping ${MOD}")
         set(MAKE_LIB OFF)
+    endif()
+
+    # Check for platform-specific modules
+    if((WIN32 AND (${MOD} STREQUAL "XwWindow"))
+        OR ((NOT WIN32) AND (${MOD} STREQUAL "WNT")))
+            message(STATUS "Skipping platform-specific module ${MOD}")
+            set(MAKE_LIB OFF)
     endif()
 
     if(MAKE_LIB)

--- a/src/XwWindow.cpp
+++ b/src/XwWindow.cpp
@@ -25,6 +25,7 @@ Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301  USA
 
 #include <Aspect_DisplayConnection.hxx>
 #include <Aspect_FBConfig.hxx>
+#include <Aspect_Window.hxx>
 #include <Xw_Window.hxx>
 
 PYBIND11_MODULE(XwWindow, mod) {


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description
<!--- Describe your changes in detail -->
When multiple versions of Python are installed, CMake can sometimes pick up the wrong Python library, such as 2.7, even though the Python interpreter is set to 3.6. 

A comment in the [CMake source](https://github.com/Kitware/CMake/blob/master/Modules/FindPythonLibs.cmake) says:
```
# If calling both ``find_package(PythonInterp)`` and
# ``find_package(PythonLibs)``, call ``find_package(PythonInterp)`` first to
# get the currently active Python version by default with a consistent version
# of PYTHON_LIBRARIES.
```
It appears that pybind11 does this, so a simple fix is to swap the order of the PYBIND11 and PYTHON blocks in CMakeLists.txt.

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->

## Screenshots (if appropriate):

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [ ] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
