### PR TITLE
 Add BOPAlgo_Options protected methods directly to BRepAlgoAPI_Algo

### DIFF
--- a/src/modules/BRepAlgoAPI.cxx
+++ b/src/modules/BRepAlgoAPI.cxx
@@ -50,6 +50,9 @@ Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301  USA
 #include <Geom_Surface.hxx>
 #include <BRepAlgoAPI_Section.hxx>
 #include <BRepAlgoAPI_Splitter.hxx>
+#include <Message_Alert.hxx>
+#include <Message_ProgressIndicator.hxx>
+#include <Message_Report.hxx>
 
 PYBIND11_MODULE(BRepAlgoAPI, mod) {
 
@@ -62,6 +65,7 @@ py::module::import("OCCT.TopTools");
 py::module::import("OCCT.BRepTools");
 py::module::import("OCCT.gp");
 py::module::import("OCCT.Geom");
+py::module::import("OCCT.Message");
 
 // CLASS: BREPALGOAPI_ALGO
 py::class_<BRepAlgoAPI_Algo, std::unique_ptr<BRepAlgoAPI_Algo, py::nodelete>, BRepBuilderAPI_MakeShape> cls_BRepAlgoAPI_Algo(mod, "BRepAlgoAPI_Algo", "Provides the root interface for the API algorithms", py::multiple_inheritance());
@@ -74,6 +78,34 @@ py::class_<BRepAlgoAPI_Algo, std::unique_ptr<BRepAlgoAPI_Algo, py::nodelete>, BR
 // cls_BRepAlgoAPI_Algo.def_static("operator new_", (void * (*)(size_t, void *)) &BRepAlgoAPI_Algo::operator new, "None", py::arg(""), py::arg("theAddress"));
 // cls_BRepAlgoAPI_Algo.def_static("operator delete_", (void (*)(void *, void *)) &BRepAlgoAPI_Algo::operator delete, "None", py::arg(""), py::arg(""));
 cls_BRepAlgoAPI_Algo.def("Shape", (const TopoDS_Shape & (BRepAlgoAPI_Algo::*)()) &BRepAlgoAPI_Algo::Shape, "None");
+
+/*
+// FIXME Access protected members of this class that are made available with "using" in BRepAlgoAPI_Algo class definition. Need to write as lambdas.
+// CLASS: BOPALGO_OPTIONS
+// Following method not accessible since protected in parent class, BOPAlgo_Options, and not exposed with using
+//cls_BRepAlgoAPI_Algo.def("Allocator", (const opencascade::handle<NCollection_BaseAllocator> & (BRepAlgoAPI_Algo::*)() const) &BRepAlgoAPI_Algo::Allocator, "Returns allocator");
+cls_BRepAlgoAPI_Algo.def("Clear", (void (BRepAlgoAPI_Algo::*)()) &BRepAlgoAPI_Algo::Clear, "Clears all warnings and errors, and any data cached by the algorithm. User defined options are not cleared.");
+// Following method not accessible since protected in parent class, BOPAlgo_Options, and not exposed with using
+//cls_BRepAlgoAPI_Algo.def("AddError", (void (BRepAlgoAPI_Algo::*)(const opencascade::handle<Message_Alert> &)) &BRepAlgoAPI_Algo::AddError, "Adds the alert as error (fail)", py::arg("theAlert"));
+// Following method not accessible since protected in parent class, BOPAlgo_Options, and not exposed with using
+//cls_BRepAlgoAPI_Algo.def("AddWarning", (void (BRepAlgoAPI_Algo::*)(const opencascade::handle<Message_Alert> &)) &BRepAlgoAPI_Algo::AddWarning, "Adds the alert as warning", py::arg("theAlert"));
+cls_BRepAlgoAPI_Algo.def("HasErrors", (Standard_Boolean (BRepAlgoAPI_Algo::*)() const) &BRepAlgoAPI_Algo::HasErrors, "Returns true if algorithm has failed");
+cls_BRepAlgoAPI_Algo.def("HasError", (Standard_Boolean (BRepAlgoAPI_Algo::*)(const opencascade::handle<Standard_Type> &) const) &BRepAlgoAPI_Algo::HasError, "Returns true if algorithm has generated error of specified type", py::arg("theType"));
+cls_BRepAlgoAPI_Algo.def("HasWarnings", (Standard_Boolean (BRepAlgoAPI_Algo::*)() const) &BRepAlgoAPI_Algo::HasWarnings, "Returns true if algorithm has generated some warning alerts");
+cls_BRepAlgoAPI_Algo.def("HasWarning", (Standard_Boolean (BRepAlgoAPI_Algo::*)(const opencascade::handle<Standard_Type> &) const) &BRepAlgoAPI_Algo::HasWarning, "Returns true if algorithm has generated warning of specified type", py::arg("theType"));
+cls_BRepAlgoAPI_Algo.def("GetReport", (const opencascade::handle<Message_Report> & (BRepAlgoAPI_Algo::*)() const) &BRepAlgoAPI_Algo::GetReport, "Returns report collecting all errors and warnings");
+cls_BRepAlgoAPI_Algo.def("DumpErrors", (void (BRepAlgoAPI_Algo::*)(Standard_OStream &) const) &BRepAlgoAPI_Algo::DumpErrors, "Dumps the error status into the given stream", py::arg("theOS"));
+cls_BRepAlgoAPI_Algo.def("DumpWarnings", (void (BRepAlgoAPI_Algo::*)(Standard_OStream &) const) &BRepAlgoAPI_Algo::DumpWarnings, "Dumps the warning statuses into the given stream", py::arg("theOS"));
+cls_BRepAlgoAPI_Algo.def("ClearWarnings", (void (BRepAlgoAPI_Algo::*)()) &BRepAlgoAPI_Algo::ClearWarnings, "Clears the warnings of the algorithm");
+cls_BRepAlgoAPI_Algo.def("SetFuzzyValue", (void (BRepAlgoAPI_Algo::*)(const Standard_Real)) &BRepAlgoAPI_Algo::SetFuzzyValue, "Sets the additional tolerance", py::arg("theFuzz"));
+cls_BRepAlgoAPI_Algo.def("FuzzyValue", (Standard_Real (BRepAlgoAPI_Algo::*)() const) &BRepAlgoAPI_Algo::FuzzyValue, "Returns the additional tolerance");
+cls_BRepAlgoAPI_Algo.def("SetProgressIndicator", (void (BRepAlgoAPI_Algo::*)(const opencascade::handle<Message_ProgressIndicator> &)) &BRepAlgoAPI_Algo::SetProgressIndicator, "Set the Progress Indicator object.", py::arg("theObj"));
+cls_BRepAlgoAPI_Algo.def("SetRunParallel", (void (BRepAlgoAPI_Algo::*)(const Standard_Boolean)) &BRepAlgoAPI_Algo::SetRunParallel, "Set the flag of parallel processing if <theFlag> is true the parallel processing is switched on if <theFlag> is false the parallel processing is switched off", py::arg("theFlag"));
+cls_BRepAlgoAPI_Algo.def("RunParallel", (Standard_Boolean (BRepAlgoAPI_Algo::*)() const) &BRepAlgoAPI_Algo::RunParallel, "Returns the flag of parallel processing");
+cls_BRepAlgoAPI_Algo.def("SetUseOBB", (void (BRepAlgoAPI_Algo::*)(const Standard_Boolean)) &BRepAlgoAPI_Algo::SetUseOBB, "Enables/Disables the usage of OBB", py::arg("theUseOBB"));
+// Following method not accessible since protected in parent class, BOPAlgo_Options, and not exposed with using
+//cls_BRepAlgoAPI_Algo.def("UseOBB", (Standard_Boolean (BRepAlgoAPI_Algo::*)() const) &BRepAlgoAPI_Algo::UseOBB, "Returns the flag defining usage of OBB");
+*/
 
 // CLASS: BREPALGOAPI_BUILDERALGO
 py::class_<BRepAlgoAPI_BuilderAlgo, BRepAlgoAPI_Algo> cls_BRepAlgoAPI_BuilderAlgo(mod, "BRepAlgoAPI_BuilderAlgo", "The class contains API level of the General Fuse algorithm.");


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description
<!--- Describe your changes in detail -->
The BRepAlgoAPI_Algo class inherits BOPAlgo_Options as protected and exposes many of the BOPAlgo_Options methods with the using keyword. Since this feature has not yet been implemented, this PR exposes these methods by directly referencing them within the BRepAlgoAPI_Algo bindings.
Addresses #25 

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->
This change exposes methods that should be available by the library.

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->
Only tested by running python code that worked using the master branch based on 7.2.0. Note that the HasWarnings, HasErrors, HasWarning, and HasError methods seem to be unstable but could be due to my python script implementation.

## Screenshots (if appropriate):

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
