### PR TITLE
Add "fix" for Font_BrepFont

### DIFF
--- a/binder/config.txt
+++ b/binder/config.txt
@@ -34,8 +34,6 @@
 
 -class Cocoa_LocalPool
 
--class Font_BRepFont
-
 -class FT_Vector
 
 -class Graphic3d_BvhCStructureSet
@@ -634,6 +632,8 @@
 +header BVH_PrimitiveSet<T, N>: bind_BVH_Object.hxx
 +header BVH_Triangulation<T, N>: bind_BVH_PrimitiveSet.hxx
 
++header Font: bind_Font_BRepFont.hxx
+
 +header Graphic3d: bind_BVH_Set.hxx
 +header Graphic3d: Precision.hxx
 
@@ -936,3 +936,8 @@
 +patch Standard: cls_GUID.def_readwrite("Data2", &Data2, "None");-->cls_Standard_UUID.def_readwrite("Data2", &Standard_UUID::Data2, "None");
 +patch Standard: cls_GUID.def_readwrite("Data3", &Data3, "None");-->cls_Standard_UUID.def_readwrite("Data3", &Standard_UUID::Data3, "None");
 
+# Font workaround
++patch Font: py::class_<Font_BRepFont, opencascade::handle<Font_BRepFont>>-->py::class_<Font_BRepFont_, std::unique_ptr<Font_BRepFont_, py::nodelete>>
++patch Font: (TopoDS_Shape (Font_BRepTextBuilder::*)(Font_BRepFont &, const Font_TextFormatter &, const gp_Ax3 &)) &Font_BRepTextBuilder::Perform-->[](Font_BRepTextBuilder &self, Font_BRepFont_ & a0, const Font_TextFormatter & a1, const gp_Ax3 & a2) -> TopoDS_Shape { return self.Perform(a0, a1, a2); }
++patch Font: (TopoDS_Shape (Font_BRepTextBuilder::*)(Font_BRepFont &, const NCollection_String &, const gp_Ax3 &, const Graphic3d_HorizontalTextAlignment, const Graphic3d_VerticalTextAlignment)) &Font_BRepTextBuilder::Perform-->[](Font_BRepTextBuilder &self, Font_BRepFont_ & a0, const NCollection_String & a1, const gp_Ax3 & a2, const Graphic3d_HorizontalTextAlignment a3, const Graphic3d_VerticalTextAlignment a4) -> TopoDS_Shape { return self.Perform(a0, a1, a2, a3, a4); }
++patch Font: Font_BRepFont &-->Font_BRepFont_ &

--- a/inc/bind_Font_BRepFont.hxx
+++ b/inc/bind_Font_BRepFont.hxx
@@ -1,0 +1,54 @@
+/*
+This file is part of pyOCCT which provides Python bindings to the OpenCASCADE
+geometry kernel.
+
+Copyright (C) 2016-2018  Laughlin Research, LLC
+Copyright (C) 2019-2020  Trevor Laughlin and the pyOCCT contributors
+
+This library is free software; you can redistribute it and/or
+modify it under the terms of the GNU Lesser General Public
+License as published by the Free Software Foundation; either
+version 2.1 of the License, or (at your option) any later version.
+
+This library is distributed in the hope that it will be useful,
+but WITHOUT ANY WARRANTY; without even the implied warranty of
+MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
+Lesser General Public License for more details.
+
+You should have received a copy of the GNU Lesser General Public
+License along with this library; if not, write to the Free Software
+Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301  USA
+*/
+#pragma once
+
+#include <pyOCCT_Common.hxx>
+#include <Font_BRepFont.hxx>
+
+class Font_BRepFont_: public Font_BRepFont {
+public:
+    //! Empty constructor
+    Standard_EXPORT Font_BRepFont_(): Font_BRepFont() {};
+
+    //! Constructor with initialization.
+    //! @param theFontPath FULL path to the font
+    //! @param theSize     the face size in model units
+    Standard_EXPORT Font_BRepFont_(
+        const NCollection_String& theFontPath,
+        const Standard_Real       theSize)
+        : Font_BRepFont(theFontPath, theSize) {};
+
+    //! Constructor with initialization.
+    //! @param theFontName    the font name
+    //! @param theFontAspect  the font style
+    //! @param theSize        the face size in model units
+    //! @param theStrictLevel search strict level for using aliases and fallback
+    Standard_EXPORT Font_BRepFont_(
+        const NCollection_String& theFontName,
+        const Font_FontAspect     theFontAspect,
+        const Standard_Real       theSize,
+        const Font_StrictLevel    theStrictLevel = Font_StrictLevel_Any)
+        : Font_BRepFont(theFontName, theFontAspect, theSize, theStrictLevel) {}
+
+    // Redefine the new & del as public
+    DEFINE_STANDARD_ALLOC
+};

--- a/test/test_Font.py
+++ b/test/test_Font.py
@@ -1,0 +1,75 @@
+# This file is part of pyOCCT which provides Python bindings to the OpenCASCADE
+# geometry kernel.
+#
+# Copyright (C) 2016-2018  Laughlin Research, LLC
+# Copyright (C) 2020 Trevor Laughlin and the pyOCCT contributors
+#
+# This library is free software; you can redistribute it and/or
+# modify it under the terms of the GNU Lesser General Public
+# License as published by the Free Software Foundation; either
+# version 2.1 of the License, or (at your option) any later version.
+#
+# This library is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
+# Lesser General Public License for more details.
+#
+# You should have received a copy of the GNU Lesser General Public
+# License along with this library; if not, write to the Free Software
+# Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301 USA
+import math
+import unittest
+
+from OCCT.Font import (
+    Font_FontMgr, Font_BRepTextBuilder, Font_FontAspect, Font_BRepFont
+)
+
+from OCCT.TCollection import TCollection_AsciiString
+from OCCT.NCollection import NCollection_String
+from OCCT.TColStd import TColStd_SequenceOfHAsciiString
+from OCCT.Graphic3d import Graphic3d_HTA_LEFT, Graphic3d_VTA_BOTTOM
+from OCCT.gp import gp_Ax3
+
+
+class Test_Font_BRepFont(unittest.TestCase):
+    """
+    Test for Font_BRepFont class.
+    """
+
+    def test_Font_BRepTextBuilder_Perform(self):
+        """
+        Test Font_BRepTextBuilder::Perform.
+        """
+
+        # Get a font (os dependent)
+        font_names = TColStd_SequenceOfHAsciiString()
+        font_mgr = Font_FontMgr.GetInstance_()
+        font_mgr.GetAvailableFontsNames(font_names)
+        self.assertGreater(font_names.Size(), 0)
+
+        font_family = TCollection_AsciiString(font_names.First().ToCString())
+
+        font_style = Font_FontAspect.Font_FA_Regular
+
+        # Create the font
+        font = Font_BRepFont()
+        assert font.FindAndInit(font_family, font_style, 12.0)
+
+        # Create builder
+        builder = Font_BRepTextBuilder()
+
+        # Parameters
+        text = NCollection_String("pyOCCT".encode("utf-8"))
+        pos = gp_Ax3()
+        halign = Graphic3d_HTA_LEFT
+        valign = Graphic3d_VTA_BOTTOM
+        topods_shape = builder.Perform(font, text, pos, halign, valign)
+
+        self.assertFalse(topods_shape.IsNull())
+
+
+if __name__ == '__main__':
+    unittest.main()
+
+
+


### PR DESCRIPTION
For #40 this is based on #43 

## Description

This is a hack/workaround that creates a `Font_BRepFont` subclass which just defines the constructors and re-adds the new / delete operators as public, then updates the `Perform` method to use the subclass class.

I'm not sure if the `py::nodelete` is needed here, I haven't tried without it.

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->
Since `Font_BRepFont` inherits `Font_FTFont` as protected it messes up pybind which cannot use new or delete from the Standard_Transient class. 

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->
Test is included, also added this into DeclaraCAD

## Screenshots (if appropriate):

![declaracad-text](https://user-images.githubusercontent.com/380158/80659697-b1eb5800-8a57-11ea-847b-872d818049fd.png)

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [ ] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
