### PR TITLE
Add patch for V3d_View so ChangeRenderParams returns a reference

### DIFF
--- a/binder/config.txt
+++ b/binder/config.txt
@@ -941,3 +941,6 @@
 +patch Font: (TopoDS_Shape (Font_BRepTextBuilder::*)(Font_BRepFont &, const Font_TextFormatter &, const gp_Ax3 &)) &Font_BRepTextBuilder::Perform-->[](Font_BRepTextBuilder &self, Font_BRepFont_ & a0, const Font_TextFormatter & a1, const gp_Ax3 & a2) -> TopoDS_Shape { return self.Perform(a0, a1, a2); }
 +patch Font: (TopoDS_Shape (Font_BRepTextBuilder::*)(Font_BRepFont &, const NCollection_String &, const gp_Ax3 &, const Graphic3d_HorizontalTextAlignment, const Graphic3d_VerticalTextAlignment)) &Font_BRepTextBuilder::Perform-->[](Font_BRepTextBuilder &self, Font_BRepFont_ & a0, const NCollection_String & a1, const gp_Ax3 & a2, const Graphic3d_HorizontalTextAlignment a3, const Graphic3d_VerticalTextAlignment a4) -> TopoDS_Shape { return self.Perform(a0, a1, a2, a3, a4); }
 +patch Font: Font_BRepFont &-->Font_BRepFont_ &
+
+# Return ref
++patch V3d: &V3d_View::ChangeRenderingParams-->&V3d_View::ChangeRenderingParams, py::return_value_policy::reference

--- a/binder/config.txt
+++ b/binder/config.txt
@@ -878,8 +878,6 @@
 +manual StdPersistent_DataXtd_Constraint-->bind_StdObjMgt_Attribute<TDataXtd_Constraint>(mod, "StdObjMgt_Attribute_TDataXtd_Constraint", py::module_local());
 +manual StdPersistent_DataXtd_PatternStd-->bind_StdObjMgt_Attribute<TDataXtd_PatternStd>(mod, "StdObjMgt_Attribute_TDataXtd_PatternStd", py::module_local());
 
-+manual V3d_View::ChangeRenderingParams-->cls_V3d_View.def("ChangeRenderingParams", (Graphic3d_RenderingParams & (V3d_View::*)()) &V3d_View::ChangeRenderingParams, py::return_value_policy::reference, "Returns reference to current rendering parameters and effect settings.");
-
 # Extra text ------------------------------------------------------------------
 +extra AIS_Line-->cls_AIS_Line.def("Points", [](AIS_Line &self, opencascade::handle<Geom_Point> & thePStart, opencascade::handle<Geom_Point> & thePEnd) {self.Points(thePStart, thePEnd); return std::tuple<opencascade::handle<Geom_Point>, opencascade::handle<Geom_Point>>(thePStart, thePEnd); }, "Returns the starting point thePStart and the end point thePEnd of the line set by SetPoints.", py::arg("thePStart"), py::arg("thePEnd"));
 
@@ -943,3 +941,6 @@
 +patch Font: (TopoDS_Shape (Font_BRepTextBuilder::*)(Font_BRepFont &, const Font_TextFormatter &, const gp_Ax3 &)) &Font_BRepTextBuilder::Perform-->[](Font_BRepTextBuilder &self, Font_BRepFont_ & a0, const Font_TextFormatter & a1, const gp_Ax3 & a2) -> TopoDS_Shape { return self.Perform(a0, a1, a2); }
 +patch Font: (TopoDS_Shape (Font_BRepTextBuilder::*)(Font_BRepFont &, const NCollection_String &, const gp_Ax3 &, const Graphic3d_HorizontalTextAlignment, const Graphic3d_VerticalTextAlignment)) &Font_BRepTextBuilder::Perform-->[](Font_BRepTextBuilder &self, Font_BRepFont_ & a0, const NCollection_String & a1, const gp_Ax3 & a2, const Graphic3d_HorizontalTextAlignment a3, const Graphic3d_VerticalTextAlignment a4) -> TopoDS_Shape { return self.Perform(a0, a1, a2, a3, a4); }
 +patch Font: Font_BRepFont &-->Font_BRepFont_ &
+
+# Return ref
++patch V3d: &V3d_View::ChangeRenderingParams-->&V3d_View::ChangeRenderingParams, py::return_value_policy::reference

--- a/binder/config.txt
+++ b/binder/config.txt
@@ -878,6 +878,8 @@
 +manual StdPersistent_DataXtd_Constraint-->bind_StdObjMgt_Attribute<TDataXtd_Constraint>(mod, "StdObjMgt_Attribute_TDataXtd_Constraint", py::module_local());
 +manual StdPersistent_DataXtd_PatternStd-->bind_StdObjMgt_Attribute<TDataXtd_PatternStd>(mod, "StdObjMgt_Attribute_TDataXtd_PatternStd", py::module_local());
 
++manual V3d_View::ChangeRenderingParams-->cls_V3d_View.def("ChangeRenderingParams", (Graphic3d_RenderingParams & (V3d_View::*)()) &V3d_View::ChangeRenderingParams, py::return_value_policy::reference, "Returns reference to current rendering parameters and effect settings.");
+
 # Extra text ------------------------------------------------------------------
 +extra AIS_Line-->cls_AIS_Line.def("Points", [](AIS_Line &self, opencascade::handle<Geom_Point> & thePStart, opencascade::handle<Geom_Point> & thePEnd) {self.Points(thePStart, thePEnd); return std::tuple<opencascade::handle<Geom_Point>, opencascade::handle<Geom_Point>>(thePStart, thePEnd); }, "Returns the starting point thePStart and the end point thePEnd of the line set by SetPoints.", py::arg("thePStart"), py::arg("thePEnd"));
 
@@ -941,6 +943,3 @@
 +patch Font: (TopoDS_Shape (Font_BRepTextBuilder::*)(Font_BRepFont &, const Font_TextFormatter &, const gp_Ax3 &)) &Font_BRepTextBuilder::Perform-->[](Font_BRepTextBuilder &self, Font_BRepFont_ & a0, const Font_TextFormatter & a1, const gp_Ax3 & a2) -> TopoDS_Shape { return self.Perform(a0, a1, a2); }
 +patch Font: (TopoDS_Shape (Font_BRepTextBuilder::*)(Font_BRepFont &, const NCollection_String &, const gp_Ax3 &, const Graphic3d_HorizontalTextAlignment, const Graphic3d_VerticalTextAlignment)) &Font_BRepTextBuilder::Perform-->[](Font_BRepTextBuilder &self, Font_BRepFont_ & a0, const NCollection_String & a1, const gp_Ax3 & a2, const Graphic3d_HorizontalTextAlignment a3, const Graphic3d_VerticalTextAlignment a4) -> TopoDS_Shape { return self.Perform(a0, a1, a2, a3, a4); }
 +patch Font: Font_BRepFont &-->Font_BRepFont_ &
-
-# Return ref
-+patch V3d: &V3d_View::ChangeRenderingParams-->&V3d_View::ChangeRenderingParams, py::return_value_policy::reference

--- a/test/test_V3d.py
+++ b/test/test_V3d.py
@@ -24,7 +24,13 @@ from OCCT.Aspect import Aspect_DisplayConnection
 from OCCT.OpenGl import OpenGl_GraphicDriver
 from OCCT.V3d import V3d_Viewer
 
+try:
+    display_connection = Aspect_DisplayConnection()
+except RuntimeError:
+    display_connection = None
 
+
+@unittest.skipIf(display_connection is None, "No display connection")
 class Test_V3d_View(unittest.TestCase):
     """
     Test for V3d_View class.
@@ -35,8 +41,7 @@ class Test_V3d_View(unittest.TestCase):
         """
         Set up with a V3d_View.
         """
-        conn = cls._display_connection = Aspect_DisplayConnection()
-        driver = cls._driver = OpenGl_GraphicDriver(conn)
+        driver = cls._driver = OpenGl_GraphicDriver(display_connection)
         viewer = cls._viewer = V3d_Viewer(driver)
         cls._view = viewer.CreateView()
 

--- a/test/test_V3d.py
+++ b/test/test_V3d.py
@@ -1,0 +1,60 @@
+# This file is part of pyOCCT which provides Python bindings to the OpenCASCADE
+# geometry kernel.
+#
+# Copyright (C) 2016-2018  Laughlin Research, LLC
+# Copyright (C) 2020 Trevor Laughlin and the pyOCCT contributors
+#
+# This library is free software; you can redistribute it and/or
+# modify it under the terms of the GNU Lesser General Public
+# License as published by the Free Software Foundation; either
+# version 2.1 of the License, or (at your option) any later version.
+#
+# This library is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
+# Lesser General Public License for more details.
+#
+# You should have received a copy of the GNU Lesser General Public
+# License along with this library; if not, write to the Free Software
+# Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301 USA
+import math
+import unittest
+
+from OCCT.Aspect import Aspect_DisplayConnection
+from OCCT.OpenGl import OpenGl_GraphicDriver
+from OCCT.V3d import V3d_Viewer
+
+
+class Test_V3d_View(unittest.TestCase):
+    """
+    Test for Geom_Surface class.
+    """
+
+    @classmethod
+    def setUpClass(cls):
+        """
+        Set up with a V3d_View.
+        """
+        conn = cls._display_connection = Aspect_DisplayConnection()
+        driver = cls._driver = OpenGl_GraphicDriver(conn)
+        viewer = cls._viewer = V3d_Viewer(driver)
+        cls._view = viewer.CreateView()
+
+    def test_V3d_View_ChangeRenderingParams(self):
+        """
+        Test V3d_View::ChangeRenderingParams.
+        """
+        view = self._view
+
+        # Update the value
+        change_params = view.ChangeRenderingParams()
+        new_value = not change_params.IsShadowEnabled
+        change_params.IsShadowEnabled = new_value
+
+        # Make sure it stuck
+        params = view.RenderingParams()
+        self.assertEqual(params.IsShadowEnabled, new_value)
+
+
+if __name__ == '__main__':
+    unittest.main()

--- a/test/test_V3d.py
+++ b/test/test_V3d.py
@@ -27,7 +27,7 @@ from OCCT.V3d import V3d_Viewer
 
 class Test_V3d_View(unittest.TestCase):
     """
-    Test for Geom_Surface class.
+    Test for V3d_View class.
     """
 
     @classmethod


### PR DESCRIPTION
Fixes #42 

## Description

V3d_View::ChangeRenderParams returns a reference that needs modified to update the rendering params. By default pybind creates a copy, this patches the function to use a reference.

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->

The rending params currently can't be changed as it modifies a copy.

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->

Built the module and tried it locally.

## Screenshots (if appropriate):

Added in #42 

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [X] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [ ] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
